### PR TITLE
Data pool improvements

### DIFF
--- a/cmd/connector/config/config.toml
+++ b/cmd/connector/config/config.toml
@@ -16,7 +16,7 @@
     WithAcknowledge = true
 
     # The duration in seconds to wait for an acknowledgement message
-    AcknowledgeTimeoutInSec = 60
+    AcknowledgeTimeoutInSec = 5
 
     # Signals if in case of data payload processing error, we should send the ack signal or not. If you want to block
     # incoming data in case of a local error, this should be set to true.

--- a/cmd/connector/config/config.toml
+++ b/cmd/connector/config/config.toml
@@ -16,7 +16,7 @@
     WithAcknowledge = true
 
     # The duration in seconds to wait for an acknowledgement message
-    AcknowledgeTimeoutInSec = 5
+    AcknowledgeTimeoutInSec = 60
 
     # Signals if in case of data payload processing error, we should send the ack signal or not. If you want to block
     # incoming data in case of a local error, this should be set to true.
@@ -57,7 +57,7 @@
     [OutportBlocksStorage.Cache]
         Name = "OutportBlocksStorage"
         # Cache capacity and size has to be higher than max allowed deltas per shards in total
-        Capacity = 100
+        Capacity = 160
         Type = "SizeLRU"
         SizeInBytes = 209715200 # 200MB
     [OutportBlocksStorage.DB]

--- a/cmd/connector/flags.go
+++ b/cmd/connector/flags.go
@@ -38,11 +38,16 @@ var (
 	dbMode = cli.StringFlag{
 		Name:  "db-mode",
 		Usage: "Option for specifying db mode. Available options: `full-persister`, `import-db`, `optimized-persister`",
-		Value: "optimized-persister",
+		Value: "full-persister",
 	}
 
 	enableGrpcServer = cli.BoolFlag{
 		Name:  "enable-grpc-server",
 		Usage: "Option for enabling grpc server",
+	}
+
+	resetCheckpoints = cli.BoolFlag{
+		Name:  "reset-checkpoints",
+		Usage: "Option for resetting state checkpoints",
 	}
 )

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -37,6 +37,7 @@ func main() {
 		disableAnsiColor,
 		dbMode,
 		enableGrpcServer,
+		resetCheckpoints,
 	}
 	app.Authors = []cli.Author{
 		{
@@ -82,7 +83,10 @@ func startConnector(ctx *cli.Context) error {
 	enableGrpcServer := ctx.GlobalBool(enableGrpcServer.Name)
 	log.Info("grpc server enabled", "enableGrpcServer", enableGrpcServer)
 
-	connectorRunner, err := connector.NewConnectorRunner(cfg, dbMode, enableGrpcServer)
+	resetCheckpoints := ctx.GlobalBool(resetCheckpoints.Name)
+	log.Info("reset checkpoint at start", "resetCheckpoints", resetCheckpoints)
+
+	connectorRunner, err := connector.NewConnectorRunner(cfg, dbMode, enableGrpcServer, resetCheckpoints)
 	if err != nil {
 		return fmt.Errorf("cannot create connector runner, error: %w", err)
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -36,3 +36,14 @@ func ConvertFirstCommitableBlocks(blocks []config.FirstCommitableBlock) (map[uin
 
 	return newBlocks, nil
 }
+
+// DeepCopyNoncesMap will deep copy nonces map
+func DeepCopyNoncesMap(originalMap map[uint32]uint64) map[uint32]uint64 {
+	newMap := make(map[uint32]uint64)
+
+	for key, value := range originalMap {
+		newMap[key] = value
+	}
+
+	return newMap
+}

--- a/connector/connectorRunner.go
+++ b/connector/connectorRunner.go
@@ -25,10 +25,11 @@ type connectorRunner struct {
 	config           *config.Config
 	dbMode           common.DBMode
 	enableGrpcServer bool
+	resetCheckpoints bool
 }
 
 // NewConnectorRunner will create a new connector runner instance
-func NewConnectorRunner(cfg *config.Config, dbMode string, enableGrpcServer bool) (*connectorRunner, error) {
+func NewConnectorRunner(cfg *config.Config, dbMode string, enableGrpcServer bool, resetCheckpoints bool) (*connectorRunner, error) {
 	if cfg == nil {
 		return nil, ErrNilConfig
 	}
@@ -37,6 +38,7 @@ func NewConnectorRunner(cfg *config.Config, dbMode string, enableGrpcServer bool
 		config:           cfg,
 		dbMode:           common.DBMode(dbMode),
 		enableGrpcServer: enableGrpcServer,
+		resetCheckpoints: resetCheckpoints,
 	}, nil
 }
 
@@ -71,6 +73,7 @@ func (cr *connectorRunner) Run() error {
 		MaxDelta:              cr.config.DataPool.MaxDelta,
 		CleanupInterval:       cr.config.DataPool.PruningWindow,
 		FirstCommitableBlocks: firstCommitableBlocks,
+		ResetCheckpoints:      cr.resetCheckpoints,
 	}
 	dataPool, err := process.NewDataPool(argsBlocksPool)
 	if err != nil {

--- a/connector/connectorRunner.go
+++ b/connector/connectorRunner.go
@@ -72,7 +72,7 @@ func (cr *connectorRunner) Run() error {
 		Marshaller:            protoMarshaller,
 		MaxDelta:              cr.config.DataPool.MaxDelta,
 		CleanupInterval:       cr.config.DataPool.PruningWindow,
-		FirstCommitableBlocks: firstCommitableBlocks,
+		FirstCommitableBlocks: common.DeepCopyNoncesMap(firstCommitableBlocks),
 		ResetCheckpoints:      cr.resetCheckpoints,
 	}
 	dataPool, err := process.NewDataPool(argsBlocksPool)
@@ -104,7 +104,7 @@ func (cr *connectorRunner) Run() error {
 		DataAggregator:              dataAggregator,
 		RetryDurationInMilliseconds: cr.config.Publisher.RetryDurationInMiliseconds,
 		Marshalizer:                 protoMarshaller,
-		FirstCommitableBlocks:       firstCommitableBlocks,
+		FirstCommitableBlocks:       common.DeepCopyNoncesMap(firstCommitableBlocks),
 	}
 
 	publisherHandler, err := process.NewPublisherHandler(publisherHandlerArgs)
@@ -117,7 +117,7 @@ func (cr *connectorRunner) Run() error {
 		gogoProtoMarshaller,
 		blocksPool,
 		outportBlockConverter,
-		firstCommitableBlocks,
+		common.DeepCopyNoncesMap(firstCommitableBlocks),
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create ws firehose data processor, error: %w", err)

--- a/connector/connectorRunner.go
+++ b/connector/connectorRunner.go
@@ -101,6 +101,7 @@ func (cr *connectorRunner) Run() error {
 		DataAggregator:              dataAggregator,
 		RetryDurationInMilliseconds: cr.config.Publisher.RetryDurationInMiliseconds,
 		Marshalizer:                 protoMarshaller,
+		FirstCommitableBlocks:       firstCommitableBlocks,
 	}
 
 	publisherHandler, err := process.NewPublisherHandler(publisherHandlerArgs)

--- a/connector/connectorRunner.go
+++ b/connector/connectorRunner.go
@@ -101,7 +101,6 @@ func (cr *connectorRunner) Run() error {
 		DataAggregator:              dataAggregator,
 		RetryDurationInMilliseconds: cr.config.Publisher.RetryDurationInMiliseconds,
 		Marshalizer:                 protoMarshaller,
-		FirstCommitableBlocks:       firstCommitableBlocks,
 	}
 
 	publisherHandler, err := process.NewPublisherHandler(publisherHandlerArgs)
@@ -114,6 +113,7 @@ func (cr *connectorRunner) Run() error {
 		gogoProtoMarshaller,
 		blocksPool,
 		outportBlockConverter,
+		firstCommitableBlocks,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create ws firehose data processor, error: %w", err)

--- a/process/blocksPool.go
+++ b/process/blocksPool.go
@@ -108,7 +108,7 @@ func (bp *blocksPool) GetShardBlock(hash []byte) (*hyperOutportBlocks.ShardOutpo
 	shardOutportBlock := &hyperOutportBlocks.ShardOutportBlock{}
 	err = bp.marshaller.Unmarshal(shardOutportBlock, marshalledData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshall shard outport block: %w", err)
 	}
 
 	return shardOutportBlock, nil

--- a/process/blocksPool.go
+++ b/process/blocksPool.go
@@ -92,7 +92,7 @@ func (bp *blocksPool) GetMetaBlock(hash []byte) (*hyperOutportBlocks.MetaOutport
 	metaOutportBlock := &hyperOutportBlocks.MetaOutportBlock{}
 	err = bp.marshaller.Unmarshal(metaOutportBlock, marshalledData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshall meta outport block: %w", err)
 	}
 
 	return metaOutportBlock, nil

--- a/process/dataPool.go
+++ b/process/dataPool.go
@@ -27,6 +27,7 @@ type dataPool struct {
 	maxDelta              uint64
 	cleanupInterval       uint64
 	firstCommitableBlocks map[uint32]uint64
+	resetCheckpoints      bool
 
 	// soft checkpoint data is being used only at startup (without any previous data)
 	// until there is a valid hard checkpoint (set by publisher)
@@ -41,6 +42,7 @@ type DataPoolArgs struct {
 	MaxDelta              uint64
 	CleanupInterval       uint64
 	FirstCommitableBlocks map[uint32]uint64
+	ResetCheckpoints      bool
 }
 
 // NewDataPool will create a new data pool instance
@@ -64,6 +66,7 @@ func NewDataPool(args DataPoolArgs) (*dataPool, error) {
 		maxDelta:              args.MaxDelta,
 		cleanupInterval:       args.CleanupInterval,
 		firstCommitableBlocks: args.FirstCommitableBlocks,
+		resetCheckpoints:      args.ResetCheckpoints,
 	}
 
 	bp.initIndexesMap()
@@ -72,6 +75,12 @@ func NewDataPool(args DataPoolArgs) (*dataPool, error) {
 }
 
 func (bp *dataPool) initIndexesMap() {
+	if bp.resetCheckpoints {
+		log.Warn("initializing with reset checkpoints option, will set empty soft checkpoint")
+		bp.softCheckpointMap = make(map[uint32]uint64)
+		return
+	}
+
 	lastCheckpoint, err := bp.GetLastCheckpoint()
 	if err == nil {
 		log.Info("initIndexesMap", "lastCheckpoint", lastCheckpoint)

--- a/process/dataPool.go
+++ b/process/dataPool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/marshal"
+	"github.com/multiversx/mx-chain-ws-connector-firehose-go/common"
 	"github.com/multiversx/mx-chain-ws-connector-firehose-go/data"
 )
 
@@ -239,19 +240,9 @@ func (bp *dataPool) getCheckpointData(checkpointKey string) (*data.BlockCheckpoi
 	return checkpoint, nil
 }
 
-func deepCopyMap(originalMap map[uint32]uint64) map[uint32]uint64 {
-	newMap := make(map[uint32]uint64)
-
-	for key, value := range originalMap {
-		newMap[key] = value
-	}
-
-	return newMap
-}
-
 func (bp *dataPool) saveLastSoftCheckpoint() error {
 	bp.mutMap.RLock()
-	softCheckpointMap := deepCopyMap(bp.softCheckpointMap)
+	softCheckpointMap := common.DeepCopyNoncesMap(bp.softCheckpointMap)
 	bp.mutMap.RUnlock()
 
 	softCheckpoint := &data.BlockCheckpoint{}

--- a/process/dataPool.go
+++ b/process/dataPool.go
@@ -239,9 +239,19 @@ func (bp *dataPool) getCheckpointData(checkpointKey string) (*data.BlockCheckpoi
 	return checkpoint, nil
 }
 
+func deepCopyMap(originalMap map[uint32]uint64) map[uint32]uint64 {
+	newMap := make(map[uint32]uint64)
+
+	for key, value := range originalMap {
+		newMap[key] = value
+	}
+
+	return newMap
+}
+
 func (bp *dataPool) saveLastSoftCheckpoint() error {
 	bp.mutMap.RLock()
-	softCheckpointMap := bp.softCheckpointMap
+	softCheckpointMap := deepCopyMap(bp.softCheckpointMap)
 	bp.mutMap.RUnlock()
 
 	softCheckpoint := &data.BlockCheckpoint{}

--- a/process/dataPool_test.go
+++ b/process/dataPool_test.go
@@ -18,7 +18,7 @@ import (
 func createDefaultBlocksPoolArgs() process.DataPoolArgs {
 	return process.DataPoolArgs{
 		Storer:          &testscommon.PruningStorerMock{},
-		Marshaller:      gogoProtoMarshaller,
+		Marshaller:      protoMarshaller,
 		MaxDelta:        10,
 		CleanupInterval: 100,
 		FirstCommitableBlocks: map[uint32]uint64{
@@ -405,9 +405,10 @@ func TestDataPool_Close(t *testing.T) {
 			return nil
 		},
 	}
-	bp, _ := process.NewDataPool(args)
+	bp, err := process.NewDataPool(args)
+	require.Nil(t, err)
 
-	err := bp.Close()
+	err = bp.Close()
 	require.Nil(t, err)
 
 	require.True(t, wasCalled)

--- a/process/dataProcessor.go
+++ b/process/dataProcessor.go
@@ -101,13 +101,13 @@ func (dp *dataProcessor) handleMetaOutportBlock(outportBlock *outport.OutportBlo
 		return fmt.Errorf("%w for blockData header", ErrInvalidOutportBlock)
 	}
 	metaNonce := metaOutportBlock.BlockData.Header.GetNonce()
+	headerHash := metaOutportBlock.BlockData.GetHeaderHash()
 
 	log.Info("saving meta outport block",
-		"hash", metaOutportBlock.BlockData.GetHeaderHash(),
+		"hash", headerHash,
 		"nonce", metaNonce,
 		"shardID", metaOutportBlock.ShardID)
 
-	headerHash := metaOutportBlock.BlockData.HeaderHash
 	err = dp.outportBlocksPool.PutBlock(headerHash, metaOutportBlock)
 	if err != nil {
 		return fmt.Errorf("failed to put metablock: %w", err)
@@ -148,12 +148,12 @@ func (dp *dataProcessor) handleShardOutportBlock(outportBlock *outport.OutportBl
 	}
 	nonce := shardOutportBlock.BlockData.Header.GetNonce()
 
+	headerHash := shardOutportBlock.BlockData.GetHeaderHash()
+
 	log.Info("saving shard outport block",
-		"hash", shardOutportBlock.BlockData.GetHeaderHash(),
+		"hash", headerHash,
 		"nonce", nonce,
 		"shardID", shardOutportBlock.ShardID)
-
-	headerHash := outportBlock.BlockData.HeaderHash
 
 	return dp.outportBlocksPool.PutBlock(headerHash, shardOutportBlock)
 }

--- a/process/dataProcessor.go
+++ b/process/dataProcessor.go
@@ -51,8 +51,7 @@ func NewDataProcessor(
 	}
 
 	dp.operationHandlers = map[string]func(marshalledData []byte) error{
-		outport.TopicSaveBlock:          dp.saveBlock,
-		outport.TopicRevertIndexedBlock: dp.revertBlock,
+		outport.TopicSaveBlock: dp.saveBlock,
 	}
 
 	return dp, nil
@@ -156,21 +155,6 @@ func (dp *dataProcessor) handleShardOutportBlock(outportBlock *outport.OutportBl
 		"shardID", shardOutportBlock.ShardID)
 
 	return dp.outportBlocksPool.PutBlock(headerHash, shardOutportBlock)
-}
-
-func (dp *dataProcessor) revertBlock(marshalledData []byte) error {
-	blockData := &outport.BlockData{}
-	err := dp.marshaller.Unmarshal(blockData, marshalledData)
-	if err != nil {
-		return err
-	}
-
-	err = dp.publisher.PublishBlock(blockData.HeaderHash)
-	if err != nil {
-		return fmt.Errorf("failed to publish block: %w", err)
-	}
-
-	return nil
 }
 
 // Close will close the internal writer

--- a/process/dataProcessor_test.go
+++ b/process/dataProcessor_test.go
@@ -89,6 +89,7 @@ func TestNewDataProcessor(t *testing.T) {
 			&testscommon.MarshallerStub{},
 			&testscommon.HyperBlocksPoolMock{},
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 		require.Nil(t, dp)
 		require.Equal(t, process.ErrNilPublisher, err)
@@ -102,6 +103,7 @@ func TestNewDataProcessor(t *testing.T) {
 			nil,
 			&testscommon.HyperBlocksPoolMock{},
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 		require.Nil(t, dp)
 		require.Equal(t, process.ErrNilMarshaller, err)
@@ -115,6 +117,7 @@ func TestNewDataProcessor(t *testing.T) {
 			&testscommon.MarshallerMock{},
 			nil,
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 		require.Nil(t, dp)
 		require.Equal(t, process.ErrNilBlocksPool, err)
@@ -128,9 +131,24 @@ func TestNewDataProcessor(t *testing.T) {
 			&testscommon.MarshallerStub{},
 			&testscommon.HyperBlocksPoolMock{},
 			nil,
+			defaultFirstCommitableBlocks,
 		)
 		require.Nil(t, dp)
 		require.Equal(t, process.ErrNilOutportBlocksConverter, err)
+	})
+
+	t.Run("nil first commitable blocks", func(t *testing.T) {
+		t.Parallel()
+
+		dp, err := process.NewDataProcessor(
+			&testscommon.PublisherMock{},
+			&testscommon.MarshallerStub{},
+			&testscommon.HyperBlocksPoolMock{},
+			&testscommon.OutportBlockConverterMock{},
+			nil,
+		)
+		require.Nil(t, dp)
+		require.Equal(t, process.ErrNilFirstCommitableBlocks, err)
 	})
 
 	t.Run("should work", func(t *testing.T) {
@@ -141,6 +159,7 @@ func TestNewDataProcessor(t *testing.T) {
 			&testscommon.MarshallerStub{},
 			&testscommon.HyperBlocksPoolMock{},
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 		require.Nil(t, err)
 		require.False(t, dp.IsInterfaceNil())
@@ -155,6 +174,7 @@ func TestDataProcessor_ProcessPayload_NotImplementedTopics(t *testing.T) {
 		&testscommon.MarshallerStub{},
 		&testscommon.HyperBlocksPoolMock{},
 		&testscommon.OutportBlockConverterMock{},
+		defaultFirstCommitableBlocks,
 	)
 
 	require.Nil(t, dp.ProcessPayload([]byte("payload"), "random topic", 1))
@@ -179,6 +199,7 @@ func TestDataProcessor_ProcessPayload(t *testing.T) {
 			gogoProtoMarshaller,
 			&testscommon.HyperBlocksPoolMock{},
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 
 		err := dp.ProcessPayload(nil, outportcore.TopicSaveBlock, 1)
@@ -200,6 +221,7 @@ func TestDataProcessor_ProcessPayload(t *testing.T) {
 			protoMarshaller,
 			&testscommon.HyperBlocksPoolMock{},
 			&testscommon.OutportBlockConverterMock{},
+			defaultFirstCommitableBlocks,
 		)
 
 		err := dp.ProcessPayload([]byte("invalid payload"), outportcore.TopicSaveBlock, 1)
@@ -223,6 +245,7 @@ func TestDataProcessor_ProcessPayload(t *testing.T) {
 				},
 			},
 			outportBlockConverter,
+			defaultFirstCommitableBlocks,
 		)
 
 		err := dp.ProcessPayload(outportBlockBytes, outportcore.TopicSaveBlock, 1)
@@ -258,6 +281,7 @@ func TestDataProcessor_ProcessPayload(t *testing.T) {
 				},
 			},
 			outportBlockConverter,
+			defaultFirstCommitableBlocks,
 		)
 
 		err = dp.ProcessPayload(outportBlockBytes, outportcore.TopicSaveBlock, 1)
@@ -281,6 +305,7 @@ func TestDataProcessor_Close(t *testing.T) {
 		&testscommon.MarshallerStub{},
 		&testscommon.HyperBlocksPoolMock{},
 		&testscommon.OutportBlockConverterMock{},
+		defaultFirstCommitableBlocks,
 	)
 	require.Nil(t, err)
 

--- a/process/export_test.go
+++ b/process/export_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-storage-go/types"
+	"github.com/multiversx/mx-chain-ws-connector-firehose-go/data"
+	"github.com/multiversx/mx-chain-ws-connector-firehose-go/data/hyperOutportBlocks"
 )
 
 const (
@@ -41,4 +43,9 @@ func (ps *pruningStorer) GetPersisterPaths() ([]string, error) {
 // CastBigInt -
 func (o *outportBlockConverter) CastBigInt(i *big.Int) ([]byte, error) {
 	return o.castBigInt(i)
+}
+
+// GetLastBlockCheckpoint -
+func (ph *publisherHandler) GetLastBlockCheckpoint(hyperOutportBlock *hyperOutportBlocks.HyperOutportBlock) (*data.BlockCheckpoint, error) {
+	return ph.getLastBlockCheckpoint(hyperOutportBlock)
 }

--- a/process/firehosePublisher_test.go
+++ b/process/firehosePublisher_test.go
@@ -30,7 +30,7 @@ func createHyperOutportBlock() *data.HyperOutportBlock {
 			ShardID: 1,
 			BlockData: &data.MetaBlockData{
 				Header: &data.MetaHeader{
-					Nonce:     1,
+					Nonce:     16,
 					PrevHash:  []byte("prev hash"),
 					TimeStamp: 100,
 				},
@@ -43,7 +43,41 @@ func createHyperOutportBlock() *data.HyperOutportBlock {
 			HighestFinalBlockNonce: 0,
 			HighestFinalBlockHash:  []byte{},
 		},
-		NotarizedHeadersOutportData: []*data.NotarizedHeaderOutportData{},
+		NotarizedHeadersOutportData: []*data.NotarizedHeaderOutportData{
+			&data.NotarizedHeaderOutportData{
+				OutportBlock: &data.ShardOutportBlock{
+					ShardID: 0,
+					BlockData: &data.BlockData{
+						ShardID: 0,
+						Header: &data.Header{
+							Nonce: 10,
+						},
+					},
+				},
+			},
+			&data.NotarizedHeaderOutportData{
+				OutportBlock: &data.ShardOutportBlock{
+					ShardID: 2,
+					BlockData: &data.BlockData{
+						ShardID: 2,
+						Header: &data.Header{
+							Nonce: 12,
+						},
+					},
+				},
+			},
+			&data.NotarizedHeaderOutportData{
+				OutportBlock: &data.ShardOutportBlock{
+					ShardID: 1,
+					BlockData: &data.BlockData{
+						ShardID: 1,
+						Header: &data.Header{
+							Nonce: 11,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	return hyperOutportBlock

--- a/process/publisherHandler.go
+++ b/process/publisherHandler.go
@@ -317,7 +317,9 @@ func (ph *publisherHandler) Close() error {
 
 	ph.cancelFunc()
 
-	close(ph.closeChan)
+	if ph.closeChan != nil {
+		close(ph.closeChan)
+	}
 
 	return nil
 }

--- a/process/publisherHandler.go
+++ b/process/publisherHandler.go
@@ -20,11 +20,12 @@ const (
 )
 
 type publisherHandler struct {
-	handler           HyperBlockPublisher
-	outportBlocksPool BlocksPool
-	dataAggregator    DataAggregator
-	retryDuration     time.Duration
-	marshaller        marshal.Marshalizer
+	handler               HyperBlockPublisher
+	outportBlocksPool     BlocksPool
+	dataAggregator        DataAggregator
+	retryDuration         time.Duration
+	marshaller            marshal.Marshalizer
+	firstCommitableBlocks map[uint32]uint64
 
 	blocksChan chan []byte
 	cancelFunc func()
@@ -41,6 +42,7 @@ type PublisherHandlerArgs struct {
 	DataAggregator              DataAggregator
 	RetryDurationInMilliseconds uint64
 	Marshalizer                 marshal.Marshalizer
+	FirstCommitableBlocks       map[uint32]uint64
 }
 
 // NewPublisherHandler creates a new publisher handler component
@@ -57,20 +59,24 @@ func NewPublisherHandler(args PublisherHandlerArgs) (*publisherHandler, error) {
 	if check.IfNil(args.Marshalizer) {
 		return nil, ErrNilMarshaller
 	}
+	if args.FirstCommitableBlocks == nil {
+		return nil, ErrNilFirstCommitableBlocks
+	}
 	if args.RetryDurationInMilliseconds < minRetryDurationInMilliseconds {
 		return nil, fmt.Errorf("%w for retry duration: provided %d, min required %d",
 			ErrInvalidValue, args.RetryDurationInMilliseconds, minRetryDurationInMilliseconds)
 	}
 
 	ph := &publisherHandler{
-		handler:           args.Handler,
-		outportBlocksPool: args.OutportBlocksPool,
-		dataAggregator:    args.DataAggregator,
-		marshaller:        args.Marshalizer,
-		retryDuration:     time.Duration(args.RetryDurationInMilliseconds) * time.Millisecond,
-		checkpoint:        &data.PublishCheckpoint{},
-		blocksChan:        make(chan []byte),
-		closeChan:         make(chan struct{}),
+		handler:               args.Handler,
+		outportBlocksPool:     args.OutportBlocksPool,
+		dataAggregator:        args.DataAggregator,
+		marshaller:            args.Marshalizer,
+		firstCommitableBlocks: args.FirstCommitableBlocks,
+		retryDuration:         time.Duration(args.RetryDurationInMilliseconds) * time.Millisecond,
+		checkpoint:            &data.PublishCheckpoint{},
+		blocksChan:            make(chan []byte),
+		closeChan:             make(chan struct{}),
 	}
 
 	var ctx context.Context
@@ -216,6 +222,22 @@ func (ph *publisherHandler) handlerHyperOutportBlock(headerHash []byte) error {
 	err = checkMetaOutportBlockHeader(metaOutportBlock)
 	if err != nil {
 		return err
+	}
+
+	metaNonce := metaOutportBlock.BlockData.Header.GetNonce()
+	shardID := metaOutportBlock.GetShardID()
+
+	firstCommitableBlock, ok := ph.firstCommitableBlocks[shardID]
+	if !ok {
+		return fmt.Errorf("failed to get first commitable block for shard %d", shardID)
+	}
+
+	if metaNonce < firstCommitableBlock {
+		// do not try to aggregate or publish hyper outport block
+
+		log.Trace("do not commit block", "currentNonce", metaNonce, "firstCommitableNonce", firstCommitableBlock)
+
+		return nil
 	}
 
 	hyperOutportBlock, err := ph.dataAggregator.ProcessHyperBlock(metaOutportBlock)

--- a/process/publisherHandler.go
+++ b/process/publisherHandler.go
@@ -282,8 +282,11 @@ func (ph *publisherHandler) getLastBlockCheckpoint(hyperOutportBlock *hyperOutpo
 		return nil, err
 	}
 
-	checkpoint := &data.BlockCheckpoint{
-		LastNonces: make(map[uint32]uint64),
+	checkpoint, err := ph.outportBlocksPool.GetLastCheckpoint()
+	if err != nil {
+		checkpoint = &data.BlockCheckpoint{
+			LastNonces: make(map[uint32]uint64),
+		}
 	}
 
 	metaBlock := hyperOutportBlock.MetaOutportBlock.BlockData.Header

--- a/process/publisherHandler.go
+++ b/process/publisherHandler.go
@@ -156,7 +156,7 @@ func (ph *publisherHandler) updatePublishCheckpoint() {
 
 func (ph *publisherHandler) handleLastCheckpointOnInit() error {
 	if ph.resetCheckpoints {
-		log.Debug("did not checked last publisher checkpoint on init")
+		log.Debug("did not check last publisher checkpoint on init")
 		return nil
 	}
 

--- a/process/publisherHandler_test.go
+++ b/process/publisherHandler_test.go
@@ -34,6 +34,7 @@ func createDefaultPublisherHandlerArgs() process.PublisherHandlerArgs {
 		DataAggregator:              &testscommon.DataAggregatorMock{},
 		Marshalizer:                 &testscommon.MarshallerMock{},
 		RetryDurationInMilliseconds: defaultRetryDuration,
+		FirstCommitableBlocks:       defaultFirstCommitableBlocks,
 	}
 }
 
@@ -82,6 +83,17 @@ func TestNewPublisherHandler(t *testing.T) {
 		ph, err := process.NewPublisherHandler(args)
 		require.Nil(t, ph)
 		require.Equal(t, process.ErrNilMarshaller, err)
+	})
+
+	t.Run("nil first commitable blocks", func(t *testing.T) {
+		t.Parallel()
+
+		args := createDefaultPublisherHandlerArgs()
+		args.FirstCommitableBlocks = nil
+
+		ph, err := process.NewPublisherHandler(args)
+		require.Nil(t, ph)
+		require.Equal(t, process.ErrNilFirstCommitableBlocks, err)
 	})
 
 	t.Run("invalid retry duration", func(t *testing.T) {
@@ -160,10 +172,54 @@ func TestPublisherHandler_PublishBlock(t *testing.T) {
 		require.True(t, wasCalled)
 	})
 
+	t.Run("should not process hyper block until first commitable block", func(t *testing.T) {
+		t.Parallel()
+
+		round := uint64(10)
+
+		firstCommitableBlocks := map[uint32]uint64{
+			core.MetachainShardId: round + 1,
+		}
+
+		metaOutportBlock := createMetaOutportBlock()
+		metaOutportBlock.BlockData.Header.Round = round
+		updateMetaStateCalled := uint32(0)
+
+		args := createDefaultPublisherHandlerArgs()
+		args.OutportBlocksPool = &testscommon.HyperBlocksPoolMock{
+			GetMetaBlockCalled: func(hash []byte) (*hyperOutportBlocks.MetaOutportBlock, error) {
+				return metaOutportBlock, nil
+			},
+			UpdateMetaStateCalled: func(checkpoint *data.BlockCheckpoint) error {
+				atomic.AddUint32(&updateMetaStateCalled, 1)
+				return nil
+			},
+		}
+		args.DataAggregator = &testscommon.DataAggregatorMock{
+			ProcessHyperBlockCalled: func(outportBlock *hyperOutportBlocks.MetaOutportBlock) (*hyperOutportBlocks.HyperOutportBlock, error) {
+				require.Fail(t, "should not have been called")
+				return nil, nil
+			},
+		}
+		args.FirstCommitableBlocks = firstCommitableBlocks
+
+		ph, err := process.NewPublisherHandler(args)
+		require.Nil(t, err)
+
+		err = ph.PublishBlock([]byte("headerHash"))
+		require.Nil(t, err)
+
+		require.Equal(t, uint32(0), atomic.LoadUint32(&updateMetaStateCalled))
+	})
+
 	t.Run("should work", func(t *testing.T) {
 		t.Parallel()
 
 		round := uint64(10)
+
+		firstCommitableBlocks := map[uint32]uint64{
+			core.MetachainShardId: round - 1,
+		}
 
 		metaOutportBlock := createMetaOutportBlock()
 		metaOutportBlock.BlockData.Header.Round = round
@@ -187,6 +243,7 @@ func TestPublisherHandler_PublishBlock(t *testing.T) {
 				return hyperOutportBlock, nil
 			},
 		}
+		args.FirstCommitableBlocks = firstCommitableBlocks
 
 		ph, err := process.NewPublisherHandler(args)
 		require.Nil(t, err)
@@ -201,6 +258,10 @@ func TestPublisherHandler_PublishBlock(t *testing.T) {
 		t.Parallel()
 
 		round := uint64(10)
+
+		firstCommitableBlocks := map[uint32]uint64{
+			core.MetachainShardId: round - 1,
+		}
 
 		metaOutportBlock := createMetaOutportBlock()
 		metaOutportBlock.BlockData.Header.Round = round
@@ -235,6 +296,7 @@ func TestPublisherHandler_PublishBlock(t *testing.T) {
 				return nil
 			},
 		}
+		args.FirstCommitableBlocks = firstCommitableBlocks
 
 		ph, err := process.NewPublisherHandler(args)
 		require.Nil(t, err)


### PR DESCRIPTION
- added last soft check in dataPool, for the case when the connector is starting and fetching shard blocks, but there are published meta blocks in the mean time (so no hard checkpoint). This is needed on restart, since without a hard checkpoint, it should realize that it should not go further then the soft - hard checkpoint gap
- added last checkpoint in published handler also: neede for the case when the connector is stopping while trying to publish a certain block. This is needed in order to avoid losing any block event
- remove revert event handling, since it's not applicable in this case